### PR TITLE
Draft of Sentry Error Triage

### DIFF
--- a/pull-requests.md
+++ b/pull-requests.md
@@ -33,6 +33,17 @@ When you think your code changes are ready to be merged to master (or a branch w
 
 - The person or team creating the pull request are responsible of testing the feature, before and __after__ it has been deployed.
 
+### Merging a Pull Request
+
+If you were assigned to a Pull Request that has a **ready to merge** tag:
+1. Do one last check of the content to see if there are any obvious mistakes.
+
+2. Merge the Pull Request
+
+3. Delete the branch
+
+4. Mark any linked Sentry errors as **resolved in the next release**
+
 ### Pull Request messages
 - If the pull request closes an issue include `closes #<issue number>` at the top of the pull request message.
 

--- a/sentry-errors.md
+++ b/sentry-errors.md
@@ -9,6 +9,7 @@ These are all the issues that nobody looked at yet. Check them out and do the fo
   * Assign the sentry-error to yourself, so it is not in the "Needs Triage" view anymore
 * You're uncertain but want to monitor it further (too few occurences to be important, might be a browser plugin)
   * Assign the sentry-error to yourself, so it is not in the "Needs Triage" view anymore.
+  * Add a comment why you chose to wait (this also gives a point of reference when it was last looked at)
   * Check up on the issue the next time
 * It's an error we can't / won't fix (Caused by a browser plugin / virus / etc.)
   * Set it to ignore forever

--- a/sentry-errors.md
+++ b/sentry-errors.md
@@ -12,6 +12,7 @@ These are all the issues that nobody looked at yet. Check them out and do the fo
   * Check up on the issue the next time
 * It's an error we can't / won't fix (Caused by a browser plugin / virus / etc.)
   * Set it to ignore forever
+  * Add a comment why we're ignoring it
 
 
 Every few weeks, look at the ignored errors and look for anything that happens too often to stay ignored.

--- a/sentry-errors.md
+++ b/sentry-errors.md
@@ -1,0 +1,17 @@
+Process for triaging new errors on Sentry
+=========================================
+
+Make it part of your process to go to Sentry and go to the "Needs Triage" view of the production project.
+These are all the issues that nobody looked at yet. Check them out and do the following.
+
+* It is an error that can be fixed:
+  * Create a GH issue and link the Sentry error to it.
+  * Assign the sentry-error to yourself, so it is not in the "Needs Triage" view anymore
+* You're uncertain but want to monitor it further (too few occurences to be important, might be a browser plugin)
+  * Assign the sentry-error to yourself, so it is not in the "Needs Triage" view anymore.
+  * Check up on the issue the next time
+* It's an error we can't / won't fix (Caused by a browser plugin / virus / etc.)
+  * Set it to ignore forever
+
+
+Every few weeks, look at the ignored errors and look for anything that happens too often to stay ignored.


### PR DESCRIPTION
@resmio/frontend @resmio/backend

This is the first draft of how we'll keep track of errors in sentry as we discussed in a meeting with the frontend team, feel free to suggest improvements!

In the backend we have basically no errors that we don't want to fix but the process should look the same.